### PR TITLE
[Suggestion] A different way of doing CSSStyleValue constructors

### DIFF
--- a/src/css-style-value.js
+++ b/src/css-style-value.js
@@ -14,15 +14,20 @@
 
 (function(internal, scope, testing) {
 
+  scope.CSSStyleValue = function(cssText) {
+    throw new TypeError('CSSStyleValue may not be instantiated');
+  }
+
   function CSSStyleValue(cssText) {
     if (!cssText) {
-      throw new TypeError('Constructing CSSStyleValues will not be available in the native implementation');
+      throw new TypeError('CSSStyleValue must have a value');
     }
-    // CSSStyleValue constructor needs to be available for type checking, but is there a way to also warn if this is constructed?
     this.cssText = cssText;
   }
 
-  CSSStyleValue.parse = function(property, cssText) {
+  CSSStyleValue.prototype = Object.create(scope.CSSStyleValue.prototype);
+
+  scope.CSSStyleValue.parse = function(property, cssText) {
     if (typeof property != 'string') {
       throw new TypeError('Property name must be a string');
     }
@@ -74,5 +79,6 @@
     return styleValueArray;
   };
 
-  scope.CSSStyleValue = CSSStyleValue;
+  internal.CSSStyleValue = CSSStyleValue;
+
 })(typedOM.internal, window);

--- a/src/style-property-map-readonly.js
+++ b/src/style-property-map-readonly.js
@@ -36,7 +36,7 @@
     if (internal.propertyDictionary().isSupportedProperty(property)) {
       return CSSStyleValue.parse(property, propertyString);
     }
-    return [new CSSStyleValue(propertyString)];
+    return [new internal.CSSStyleValue(propertyString)];
   };
 
   StylePropertyMapReadOnly.prototype.getProperties = function() {

--- a/test/js/css-style-value.js
+++ b/test/js/css-style-value.js
@@ -36,4 +36,8 @@ suite('CSSStyleValue', function() {
   test('parse throws an error if a cssText representing a CSSStyleValue type unsupported by a property is entered', function() {
     assert.throws(function() {CSSStyleValue.parse('height', '10')}, TypeError, 'height has an unsupported CSSStyleValue type or Sequence value separator');
   });
+
+  test('instantiating CSSStyleValue throws', function() {
+    assert.throws(function() {new CSSStyleValue('10px')}, TypeError, 'CSSStyleValue may not be instantiated');
+  });
 });


### PR DESCRIPTION
Makes an external CSSStyleValue constructor which throws, and an internal CSSStyleValue constructor for use when an unsupported property is queried. instanceof CSSStyleValue works for both.

What do you think?
